### PR TITLE
Add a check for empty messages for the ERS-kafka database writer

### DIFF
--- a/ers-dbwriter/dbwriter.py
+++ b/ers-dbwriter/dbwriter.py
@@ -86,6 +86,8 @@ def cli(filename):
     # Infinite loop over the kafka messages
     for message in consumer:
         js = json.loads(message.value)
+        if js == '[]':
+            continue
         ls = [str(js[key]) for key in fields]
 
         try:


### PR DESCRIPTION
A few days ago there were empty messages and the ERS-kafka writer crashed so let's avoid that in the future.