### PR TITLE
Improve the ERS database writer

### DIFF
--- a/ers-dbwriter/Dockerfile
+++ b/ers-dbwriter/Dockerfile
@@ -5,7 +5,6 @@ RUN yum -y install python3-pip python3-devel libpq-devel gcc \
 
 COPY requirements.txt /
 COPY dbwriter.py /
-COPY .auth /
 
 RUN pip3 install -r requirements.txt
 

--- a/ers-dbwriter/README.md
+++ b/ers-dbwriter/README.md
@@ -1,0 +1,38 @@
+`dbwriter.py` is the script responsible for taking the ERS messages from kafka
+and writing to a postgreSQL database so that the messages can be displayed in a
+grafana dashboard. The secrets to connect to the database are obtained from
+environment variables. To run it manually do:
+```python dbwriter.py```
+and if the env variables are set, it should start printing the messages that it
+is receiving and writing to the database.
+
+# Deploying on kubernetes
+First, we need to make the secrets. Create a yaml file containing the secrets:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ers-secret
+  namespace: monitoring
+type: Opaque
+data:
+  ERS_DBWRITER_HOST:
+  ERS_DBWRITER_PORT:
+  ERS_DBWRITER_USER:
+  ERS_DBWRITER_PASS:
+  ERS_DBWRITER_NAME:
+```
+where after each of the env variables the secret goes in base64 form (can be obtained by doing `echo -n "secret" | base64`)
+If all went well when we do `kubectl get secrets`
+we should see something like
+```
+NAME         TYPE     DATA   AGE
+ers-secret   Opaque   5      37m
+```
+Once the secrets are set, do `kubectl apply -f manifest.yaml` with the corresponding manifest. 
+We can get the pod name by doing `kubectl -n monitoring get pods` and then it will show something like
+```
+NAME                           READY   STATUS    RESTARTS   AGE
+erskafka-7dfdf88864-4mwvd      1/1     Running   0          15m
+```
+where the important part is that `STATUS` is `Running`

--- a/ers-dbwriter/dbwriter.py
+++ b/ers-dbwriter/dbwriter.py
@@ -10,10 +10,41 @@ import json
 import click
 import os
 
-@click.command()
-@click.option('--filename', type=click.Path(), default='./.auth', required=False,
-              help='Secrets related to the Postgre SQL database')
-def cli(filename):
+def clean_database(cursor, connection):
+    cursor.execute('''
+                DROP TABLE public."ErrorReports";
+                ''')
+    connection.commit()
+
+def create_database(cursor, connection):
+    cursor.execute('''
+                CREATE TABLE public."ErrorReports" (
+                partition           TEXT,
+                issue_name          TEXT,
+                message             TEXT,
+                severity            TEXT,
+                usecs_since_epoch   BIGINT,
+                time                BIGINT,
+                qualifiers          TEXT,
+                params              TEXT,
+                cwd                 TEXT,
+                file_name           TEXT,
+                function_name       TEXT,
+                host_name           TEXT,
+                package_name        TEXT,
+                user_name           TEXT,
+                application_name    TEXT,
+                user_id             INT,
+                process_id          INT,
+                thread_id           INT,
+                line_number         INT,
+                chain               TEXT
+               );
+               '''
+                )
+    connection.commit()
+
+def main():
     consumer = KafkaConsumer('erskafka-reporting',
                             bootstrap_servers='monkafka.cern.ch:30092',
                             group_id='group1')
@@ -26,60 +57,25 @@ def cli(filename):
 
     try:
         con = psycopg2.connect(host=host,
-                            port=port,
-                            user=user,
-                            password=password,
-                            dbname=dbname)
+                               port=port,
+                               user=user,
+                               password=password,
+                               dbname=dbname)
     except:
         print('Connection to the database failed, aborting...')
         exit()
 
     # These are the fields in the ERS messages, see erskafka/src/KafkaStream.cpp
     fields = ["partition", "issue_name", "message", "severity", "usecs_since_epoch", "time",
-            "qualifiers", "params", "cwd", "file_name", "function_name", "host_name",
-            "package_name", "user_name", "application_name", "user_id", "process_id",
-            "thread_id", "line_number", "chain"]
+              "qualifiers", "params", "cwd", "file_name", "function_name", "host_name",
+              "package_name", "user_name", "application_name", "user_id", "process_id",
+              "thread_id", "line_number", "chain"]
 
     cur = con.cursor()
 
-    # Uncomment to clean the database
-    # cur.execute('''
-    #             DROP TABLE public."ErrorReports";
-    #             ''')
-    # con.commit()
-    # exit()
-
-    # Uncomment to create the table used for the database
-    # cur.execute('''
-    #             CREATE TABLE public."ErrorReports" (
-    #             partition           TEXT,
-    #             issue_name          TEXT,
-    #             message             TEXT,
-    #             severity            TEXT,
-    #             usecs_since_epoch   BIGINT,
-    #             time                BIGINT,
-    #             qualifiers          TEXT,
-    #             params              TEXT,
-    #             cwd                 TEXT,
-    #             file_name           TEXT,
-    #             function_name       TEXT,
-    #             host_name           TEXT,
-    #             package_name        TEXT,
-    #             user_name           TEXT,
-    #             application_name    TEXT,
-    #             user_id             INT,
-    #             process_id          INT,
-    #             thread_id           INT,
-    #             line_number         INT,
-    #             chain               TEXT
-    #            );
-    #            '''
-    #             )
-    # con.commit()
-    # exit()
-
     # Infinite loop over the kafka messages
     for message in consumer:
+        print(message)
         js = json.loads(message.value)
         if js == '[]':
             continue
@@ -87,12 +83,15 @@ def cli(filename):
 
         try:
             cur.execute(f'INSERT INTO public."ErrorReports" ({",".join(fields)}) VALUES({("%s, " * len(ls))[:-2]})', ls)
-        except:
-            print('Query to insert in the database failed. This is the message received')
-            print(message)
-
-        # Save the insert (or any change) to the database
-        con.commit()
+            # Save the insert (or any change) to the database
+            con.commit()
+        except psycopg2.errors.UndefinedTable:
+            con.rollback()
+            create_database(cur, con)
+        except psycopg2.errors.UndefinedColumn:
+            con.rollback()
+            clean_database(cur, con)
+            create_database(cur, con)
 
 if __name__ == '__main__':
-    cli()
+    main()

--- a/ers-dbwriter/dbwriter.py
+++ b/ers-dbwriter/dbwriter.py
@@ -7,7 +7,6 @@
 from kafka import KafkaConsumer
 import psycopg2
 import json
-import click
 import os
 
 def clean_database(cursor, connection):

--- a/ers-dbwriter/dbwriter.py
+++ b/ers-dbwriter/dbwriter.py
@@ -1,6 +1,5 @@
-#
 # @file dbwriter.py Writing ERS info to PostgreSQL database
-# This is part of the DUNE DAQ software, copyright 2020.
+#  This is part of the DUNE DAQ software, copyright 2020.
 #  Licensing/copyright details are in the COPYING file that you should have
 #  received with this code.
 #
@@ -9,6 +8,7 @@ from kafka import KafkaConsumer
 import psycopg2
 import json
 import click
+import os
 
 @click.command()
 @click.option('--filename', type=click.Path(), default='./.auth', required=False,
@@ -18,16 +18,11 @@ def cli(filename):
                             bootstrap_servers='monkafka.cern.ch:30092',
                             group_id='group1')
 
-    # Get credentials, it expects a file with the following fields, each in a different line:
-
-    # host
-    # port
-    # user
-    # password
-    # dbname
-
-    with open(filename) as f:
-        host, port, user, password, dbname = f.read().split('\n')
+    host = os.environ['ERS_DBWRITER_HOST']
+    port = os.environ['ERS_DBWRITER_PORT']
+    user = os.environ['ERS_DBWRITER_USER']
+    password = os.environ['ERS_DBWRITER_PASS']
+    dbname = os.environ['ERS_DBWRITER_NAME']
 
     try:
         con = psycopg2.connect(host=host,

--- a/ers-dbwriter/requirements.txt
+++ b/ers-dbwriter/requirements.txt
@@ -1,3 +1,2 @@
 kafka-python
 psycopg2-binary
-click


### PR DESCRIPTION
This PR adds better handling of the cases when 
- The postgres database is removed, now the database will be created automatically 
- The postgres database is restored to a state that doesn't correspond to the columns that we are using, now the database will be deleted and recreated with the correct columns

Both cases seem to be happening often; the postgres database should have persistence so that it is not deleted / reseted every time the cluster goes down

Also the secrets are now obtained from env variables instead of a file