### PR TITLE
Try to permit running container as non-root

### DIFF
--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -1,17 +1,15 @@
-FROM dunedaq/c8-minimal
+FROM ghcr.io/dune-daq/c8-minimal:latest
+
+EXPOSE 5003
 
 RUN yum clean all \
- && yum -y install python3-pip \
- && yum -y install python3-devel \
+ && yum -y install python3 python3-pip python3-wheel \
  && yum clean all
 
-COPY conf-service.py / 
-COPY configconfig.py /
-COPY requirements.txt / 
+COPY conf-service.py  configconfig.py requirements.txt / 
 
-RUN pip3 install --upgrade pip
-RUN pip3 install -r /requirements.txt
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install -r /requirements.txt
 
-COPY entrypoint.sh /
-RUN ["chmod", "+x", "/entrypoint.sh"]
+COPY --chmod=755 entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/config-service/conf-service.py
+++ b/config-service/conf-service.py
@@ -30,7 +30,7 @@ from flask_restful import Api, Resource, reqparse
 from flask_caching import Cache
 from apispec import APISpec
 from bson.json_util import loads, dumps
-__version__='1.0.0'
+__version__='1.0.1'
 
 '''
 Preliminary setup
@@ -52,21 +52,8 @@ ch.setFormatter(formatter)
 log.addHandler(fh)
 log.addHandler(ch)
 
-# Mongo connection
-mongo_client = None
-mongo_db = None
-coll_configs = None
-mongo_connection_string = f'mongodb://{config.mongo_user}:{config.mongo_pass}@{config.mongo_host}:{config.mongo_port}'
-# mongo_connection_string = f'mongodb://localhost:27017'
-try:
-  mongo_client = MongoClient(mongo_connection_string)
-  mongo_db = mongo_client[config.mongo_db]
-except:
-  log.error('Please check your configuration details for the MongoDB connection!')
-  exit(1)
-
 def resource_not_found(e):
-    return jsonify(error=str(e)), 404
+    return flask.jsonify(error=str(e)), 404
 
 '''
 Resources
@@ -250,6 +237,32 @@ class ListVersions(BaseResource):
         configs['versions'].append(k['version'])
 
     return flask.make_response( flask.jsonify( configs ))
+
+'''
+Mongo connection
+'''
+mongo_client = None
+mongo_db = None
+coll_configs = None
+if config.mongo_pass != '':
+  mongo_connection_string = f'mongodb://{config.mongo_user}:{config.mongo_pass}@{config.mongo_host}:{config.mongo_port}'
+elif config.mongo_user != '':
+  mongo_connection_string = f'mongodb://{config.mongo_user}@{config.mongo_host}:{config.mongo_port}'
+else:
+  mongo_connection_string = f'mongodb://{config.mongo_host}:{config.mongo_port}'
+
+try:
+  mongo_client = MongoClient(mongo_connection_string)
+  mongo_db = mongo_client[config.mongo_db]
+except:
+  log.error('Please check your configuration details for the MongoDB connection!')
+  log.error(f'base connection_string=mongodb://{config.mongo_host}:{config.mongo_port}/{config.mongo_db}')
+  log.error(f'connection_username="{config.mongo_user}"')
+  if config.mongo_pass != '':
+    log.error('connection_password is defined')
+  else:
+    log.error('connection_password is NOT defined')
+  exit(1)
 
 '''
 Main flask app

--- a/config-service/configconfig.py
+++ b/config-service/configconfig.py
@@ -1,8 +1,10 @@
+import os
+
+mongo_host=os.environ.get('MONGO_HOST', 'localhost')
+mongo_port=os.environ.get('MONGO_PORT', '27017')
+mongo_user=os.environ.get('MONGO_USER','')
+mongo_pass=os.environ.get('MONGO_PASS','')
+mongo_db=os.environ.get('MONGO_DBNAME','daqconfigdb')
 logfile='/tmp/config-archiver.log'
-mongo_host='MONGO_HOST'
-mongo_port='MONGO_PORT'
-mongo_user='MONGO_USER'
-mongo_pass='MONGO_PASS'
-mongo_db='daqconfigdb'
 service_host='localhost'
 service_port=5003

--- a/config-service/configservice.yml
+++ b/config-service/configservice.yml
@@ -1,0 +1,104 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels: # https://github.com/bitnami/charts/pull/17236
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn-version: latest
+  name: daqconfig
+---
+# You must still deploy mongodb with its manifests from upstream
+# and create a secret called mongodb-svcbind-daqconfig with the required keys.
+# The ServiceBinding secret from bitnami is such a secret.
+# https://github.com/bitnami/charts/issues/17411
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/app: config-utility
+    app.kubernetes.io/component: config-utility
+  name: config-utility
+  namespace: daqconfig
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/app: config-utility
+      app.kubernetes.io/component: config-utility
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/app: config-utility
+        app.kubernetes.io/component: config-utility
+    spec:
+      containers:
+      - env:
+        - name: MONGO_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mongodb-svcbind-daqconfig
+        - name: MONGO_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mongodb-svcbind-daqconfig
+        - name: MONGO_USER
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mongodb-svcbind-daqconfig
+        - name: MONGO_PASS
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mongodb-svcbind-daqconfig
+        - name: MONGO_DBNAME
+          valueFrom:
+            secretKeyRef:
+              key: database
+              name: mongodb-svcbind-daqconfig
+        image: ghcr.io/dune-daq/daqconfig-service:v1.0.1
+        name: daqconfig-service
+        ports:
+        - containerPort: 5003
+          name: http
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 8Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 11000
+          runAsNonRoot: true
+          runAsUser: 11000
+          seccompProfile:
+            type: RuntimeDefault
+      securityContext:
+        fsGroup: 11000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/app: config-utility
+    app.kubernetes.io/component: config-utility
+  name: daqconfig
+  namespace: daqconfig
+spec:
+  ports:
+  - port: 5003
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/app: config-utility
+    app.kubernetes.io/component: config-utility
+  type: ClusterIP

--- a/config-service/entrypoint.sh
+++ b/config-service/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-sed -i -e "s%MONGO_HOST%${MONGO_HOST}%g" configconfig.py
-sed -i -e "s%MONGO_PORT%${MONGO_PORT}%g" configconfig.py
-sed -i -e "s%MONGO_USER%${MONGO_USER}%g" configconfig.py
-sed -i -e "s%MONGO_PASS%${MONGO_PASS}%g" configconfig.py
+
+echo "You should probably define env vars for:"
+echo " MONGO_HOST, MONGO_PORT, MONGO_USER, MONGO_PASS, MONGO_DBNAME"
 
 exec gunicorn -b 0.0.0.0:5003 --workers=1 --worker-class=gevent --timeout 5000000000 --log-level=debug conf-service:app


### PR DESCRIPTION
In theory this should preserve the simplicity of overriding the connection settings but also let the container run as a non-root user for security.

Do we know what rational cpu/ram limits might look like for this service?

I've included updates to the Dockerfile and an example kubernetes manifest for how this could be deployed.  Should we host the container on the github registry via github workflows?  @dingp knows how that is done...

https://github.com/orgs/DUNE-DAQ/packages/container/package/pocket-connectivityserver may hold some initial progress.
