### PR TITLE
Try to permit container to run as non-root

### DIFF
--- a/runregistry-rest/Dockerfile
+++ b/runregistry-rest/Dockerfile
@@ -1,25 +1,24 @@
-FROM dunedaq/pocket-runregistry-rest:0.2
+# this should move to github container registry at some point
+# and should probably be based on one of our baseline containers
+FROM docker.io/dunedaq/pocket-runregistry-rest:0.2
 
 #RUN yum clean all \
-# && yum -y install python3-pip \
 # && yum -y install python3-devel \
+# && yum -y install python3-pip \
+# && yum -y install python3-wheel \
 # && yum --enablerepo=cernonly -y install oracle-instantclient12.1-devel \
 # && yum --enablerepo=cernonly -y install oracle-instantclient-tnsnames.ora \
 # && yum clean all
 
-COPY authentication.py /
-COPY credentials.py /
-COPY rest.py /
-COPY ./backends/. /backends/
-COPY requirements.txt /
+# ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib/
 
-RUN mkdir /uploads
+COPY authentication.py credentials.py rest.py requirements.txt /
+COPY ./backends/. /backends/
+
+RUN mkdir --mode=1777 /uploads
 
 RUN pip3 install --upgrade pip
 RUN pip3 install -r /requirements.txt
 
-ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib/
-
-COPY entrypoint.sh /
-RUN ["chmod", "+x", "/entrypoint.sh"]
+COPY --chmod=755 entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/runregistry-rest/backends/pg_backend.py
+++ b/runregistry-rest/backends/pg_backend.py
@@ -8,9 +8,9 @@ print("psycopg2 client version: ", str(psycopg2.__version__))
 db_conn = psycopg2.connect(
     user=credentials.user,
     password=credentials.password,
-    host=credentials.dburi,
+    host=credentials.dbhost,
     port=credentials.port,
-    database=credentials.database,
+    dbname=credentials.database,
 )
 
 print("Postgres connection:", str(db_conn))

--- a/runregistry-rest/credentials.py
+++ b/runregistry-rest/credentials.py
@@ -1,5 +1,16 @@
-dburi = "Secret from Kubernetes!"
-user = "Secret from Kubernetes!"
-password = "Secret from Kubernetes!"
-port = "Secret from Kubernetes!"
-database = "Secret from Kubernetes!"
+import os
+
+if os.environ.get("RGDB", None) == "postgres":
+    dbhost = os.environ.get("DB_HOSTNAME", "localhost")
+    port = os.environ.get("DB_PORT", 5432)
+    database = os.environ.get("DB_NAME", "runregistry")
+
+    username = os.environ.get("DB_USERNAME", "")
+    password = os.environ.get("DB_PASSWORD", "")
+else:  # is oracle?
+    dburi = "FIX ME to be a Secret from Kubernetes with good defaults!"
+    port = os.environ.get("DB_PORT", 1521)
+    database = "set default database name here"
+
+    username = os.environ.get("DB_USERNAME", "")
+    password = os.environ.get("DB_PASSWORD", "")

--- a/runregistry-rest/entrypoint.sh
+++ b/runregistry-rest/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-sed -i "s/dburi\='Secret from Kubernetes\!'/dburi\='${RGURI}'/g" /credentials.py
-sed -i "s/user\='Secret from Kubernetes\!'/user\='${RGUSER}'/g" /credentials.py
-sed -i "s/password\='Secret from Kubernetes\!'/password\='${RGPASS}'/g" /credentials.py
-sed -i "s/port\='Secret from Kubernetes\!'/port\='${RGPORT}'/g" /credentials.py
-sed -i "s/database\='Secret from Kubernetes\!'/database\='${RGDBNAME}'/g" /credentials.py
+echo "You should probably define env vars for:"
+echo "  DB_HOSTNAME, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD"
 
 exec gunicorn -b 0.0.0.0:5005 --workers=1 --worker-class=gevent --timeout 5000000000 --log-level=debug rest:app

--- a/runregistry-rest/kubernetes.yaml
+++ b/runregistry-rest/kubernetes.yaml
@@ -1,0 +1,106 @@
+---
+# You must still deploy your database with its manifests from upstream
+# and create a secret called runregistry-rest-app - CNPG makes this automatically
+#   containing keys: username, password
+# and create a secret called runregistry-rest-database - CF. servicebinding.io
+#   containing keys: hostname, port, dbname
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/app: runregistry-rest
+    app.kubernetes.io/component: runregistry-rest
+  name: runregistry-rest
+  namespace: runcounter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/app: runregistry-rest
+      app.kubernetes.io/component: runregistry-rest
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/app: runregistry-rest
+        app.kubernetes.io/component: runregistry-rest
+    spec:
+      containers:
+      - env:
+        - name: RGDB
+          value: postgres
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: runregistry-rest-app
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: runregistry-rest-app
+        - name: DB_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              key: hostname
+              name: runregistry-rest-database
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: runregistry-rest-database
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: dbname
+              name: runregistry-rest-database
+        image: ghcr.io/dune-daq/pocket-runregistry-rest:0.9
+        name: runregistry-rest
+        ports:
+        - containerPort: 5005
+          name: http
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 8Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 11000
+          runAsNonRoot: true
+          runAsUser: 11000
+          seccompProfile:
+            type: RuntimeDefault
+      securityContext:
+        fsGroup: 11000
+      volumeMounts:
+      - mountPath: /uploads
+        name: uploads-volume
+    volumes: # persistance is not required at this time
+    - name: uploads-volume
+      emptyDir:
+        sizeLimit: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/app: runregistry-rest
+    app.kubernetes.io/component: runregistry-rest
+  name: runregistry-rest-svc
+  namespace: runcounter
+spec:
+  ports:
+  - name: http
+    port: 5005
+    protocol: TCP
+    targetPort: 5005
+  selector:
+    app.kubernetes.io/app: runregistry-rest
+    app.kubernetes.io/component: runregistry-rest
+  type: ClusterIP


### PR DESCRIPTION
In theory this permits the container to run as a non-root user.  It will require a rebuild and push of the container to the gh registry.

This will need some rework after https://github.com/DUNE-DAQ/microservices/pull/37 is merged, but it shouldn't be too bad.

How much persistence do you need with `/uploads`?  Should that be a stable kubernetes volume?