### PR TITLE
Set default user to non-root

### DIFF
--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -8,8 +8,9 @@ RUN yum clean all \
 
 COPY conf-service.py  configconfig.py requirements.txt / 
 
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install -r /requirements.txt
+RUN python3 -m pip install --upgrade pip && python3 -m pip install -r /requirements.txt && pip cache remove *
 
 COPY --chmod=755 entrypoint.sh /
+
+USER 10000:0
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ers-dbwriter/Dockerfile
+++ b/ers-dbwriter/Dockerfile
@@ -3,9 +3,9 @@ FROM dunedaq/c8-minimal
 RUN yum -y install python3-pip python3-devel libpq-devel gcc \
  && yum clean all
 
-COPY requirements.txt /
-COPY dbwriter.py /
+COPY requirements.txt dbwriter.py /
 
-RUN pip3 install -r requirements.txt
+RUN python3 -m pip install --upgrade pip && python3 -m pip install -r /requirements.txt && pip cache remove *
 
+USER 10000:0
 ENTRYPOINT ["python3", "dbwriter.py"]

--- a/logbook/Dockerfile
+++ b/logbook/Dockerfile
@@ -1,5 +1,7 @@
 FROM cern/cc7-base AS builder
 
+EXPOSE 5005
+
 RUN yum clean all \
  && yum update -y
 
@@ -27,6 +29,7 @@ COPY cern-get-sso-cookie /usr/local/bin
 RUN pip install -r /requirements.txt \
  && pip install ./elisa_client_api \
  && mkdir -p ./logfiles
+ && pip cache remove *
 
-EXPOSE 5005
+USER 10000:0
 CMD ["python3.9", "logbook.py"]

--- a/opmon-dbwriter/Dockerfile
+++ b/opmon-dbwriter/Dockerfile
@@ -3,9 +3,9 @@ FROM dunedaq/c8-minimal
 RUN yum -y install python3-pip python3-devel libpq-devel gcc \
  && yum clean all
 
-COPY requirements.txt /
-COPY kafka-to-influx.py /
+COPY requirements.txt kafka-to-influx.py /
 
-RUN pip3 install -r requirements.txt
+RUN python3 -m pip install --upgrade pip && python3 -m pip install -r /requirements.txt && pip cache remove *
 
+USER 10000:0
 ENTRYPOINT ["python3", "kafka-to-influx.py"]

--- a/runnumber-rest/Dockerfile
+++ b/runnumber-rest/Dockerfile
@@ -7,18 +7,12 @@ RUN yum clean all \
  && yum --enablerepo=cernonly -y install oracle-instantclient-tnsnames.ora \
  && yum clean all
 
-COPY authentication.py /
-COPY credentials.py /
-COPY rest.py /
-COPY backend.py /
-COPY queries.py /
-COPY requirements.txt /
+COPY authentication.py credentials.py rest.py backend.py queries.py requirements.txt /
 
-RUN pip3 install --upgrade pip
-RUN pip3 install -r /requirements.txt
+RUN python3 -m pip install --upgrade pip && python3 -m pip install -r /requirements.txt && pip cache remove *
 
+COPY --chmod=755 entrypoint.sh /
+
+USER 10000:0
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib/
-
-COPY entrypoint.sh /
-RUN ["chmod", "+x", "/entrypoint.sh"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/runregistry-rest/Dockerfile
+++ b/runregistry-rest/Dockerfile
@@ -17,8 +17,9 @@ COPY ./backends/. /backends/
 
 RUN mkdir --mode=1777 /uploads
 
-RUN pip3 install --upgrade pip
-RUN pip3 install -r /requirements.txt
+RUN python3 -m pip install --upgrade pip && python3 -m pip install -r /requirements.txt && pip cache remove *
 
 COPY --chmod=755 entrypoint.sh /
+
+USER 10000:0
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This should default users in the containers to non-root following container best practices.  Depressingly a GID `0` is expected by a distressing number of tools.