### PR TITLE
Describe kafka grouping for log traces

### DIFF
--- a/ers-dbwriter/dbwriter.py
+++ b/ers-dbwriter/dbwriter.py
@@ -46,7 +46,7 @@ def create_database(cursor, connection):
 def main():
     consumer = KafkaConsumer('erskafka-reporting',
                             bootstrap_servers='monkafka.cern.ch:30092',
-                            group_id='group1')
+                            group_id='ers-dbwriter')
 
     host = os.environ['ERS_DBWRITER_HOST']
     port = os.environ['ERS_DBWRITER_PORT']


### PR DESCRIPTION
This helps keep track of which things are consumers in the logs.  `group` wasn't very descriptive.