### PR TITLE
Fix mkdir

### DIFF
--- a/runregistry-rest/entrypoint.sh
+++ b/runregistry-rest/entrypoint.sh
@@ -7,7 +7,7 @@ source ../entrypoint_functions.sh
 ensure_required_variables "DB_HOSTNAME DB_PORT DB_NAME DB_USERNAME DB_PASSWORD"
 
 
-mkdir --mode=1777 /uploads
+mkdir --mode=1777 uploads
 
 export LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib/:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
The `mkdir` was incorrectly using the absolute path when the relative path is required.