### PR TITLE
Don't mount k8s api credentials by default

### DIFF
--- a/config-service/config-service-deployment.yaml
+++ b/config-service/config-service-deployment.yaml
@@ -43,6 +43,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/microservices:latest
         imagePullPolicy: Always

--- a/elisa-logbook/elisa-logbook-deployment.yaml
+++ b/elisa-logbook/elisa-logbook-deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/microservices:latest
         name: elisa-logbook

--- a/ers-dbwriter/ers-dbwriter-deployment.yaml
+++ b/ers-dbwriter/ers-dbwriter-deployment.yaml
@@ -47,6 +47,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/microservices:9e36
         imagePullPolicy: Always

--- a/ers-protobuf-dbwriter/ers-dbwriter-deployment.yaml
+++ b/ers-protobuf-dbwriter/ers-dbwriter-deployment.yaml
@@ -47,6 +47,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/microservices:9685
         imagePullPolicy: Always

--- a/opmon-protobuf-dbwriter/opmon-dbwriter-deployment.yaml
+++ b/opmon-protobuf-dbwriter/opmon-dbwriter-deployment.yaml
@@ -40,6 +40,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/microservices:mroda-opmon_protobuf   ## TBC
         imagePullPolicy: Always

--- a/runnumber-rest/runnumber-rest-deployment.yaml
+++ b/runnumber-rest/runnumber-rest-deployment.yaml
@@ -42,6 +42,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/microservices:latest
         imagePullPolicy: Always

--- a/runregistry-rest/runregistry-rest-deployment.yaml
+++ b/runregistry-rest/runregistry-rest-deployment.yaml
@@ -42,6 +42,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/microservices:latest
         imagePullPolicy: Always


### PR DESCRIPTION
The k8s security docs recommend disabling the API credentials unless the application directly queries the k8s API.